### PR TITLE
forcing type keyword on imports

### DIFF
--- a/src/formatErrorsPerFile.ts
+++ b/src/formatErrorsPerFile.ts
@@ -1,4 +1,4 @@
-import { Annotation } from './utils/normalizeErrors';
+import type { Annotation } from './utils/normalizeErrors';
 import { table } from 'table';
 import { NO_STYLES_IN_TABLE } from './utils/constants';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "strictPropertyInitialization": true,
+    "importsNotUsedAsValues": "error",
     "noImplicitThis": true,
     "alwaysStrict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
It is cleaner to distinguish between type imports and normal imports, so enforcing the ts rule. 