### PR TITLE
ignore binding error when reporting annotations

### DIFF
--- a/__fixtures__/scenarios/failed_case.json
+++ b/__fixtures__/scenarios/failed_case.json
@@ -1,6 +1,11 @@
 {
   "errors": {
-    "runtime": [{ "id": "47b5f893-b617-498f-a644-09bbdf88f014", "errors": ["cannot initialize input plugin: john"] }],
+    "runtime": [
+      {
+        "id": "47b5f893-b617-498f-a644-09bbdf88f014",
+        "errors": ["cannot initialize input plugin: john", "Error binding socket"]
+      }
+    ],
     "input": {
       "syslog": [
         {

--- a/dist/index.js
+++ b/dist/index.js
@@ -28155,6 +28155,7 @@ var ATTRIBUTE_NAME_MISSING = 'Attribute "name" missing';
 
 // src/utils/normalizeErrors.ts
 var import_path = require('path');
+var IGNORE_LIST = ['Error binding socket'];
 function getRelativeFilePath(filePath) {
   const relativePath = filePath.replace((0, import_path.join)(process.env.GITHUB_WORKSPACE, '/'), '');
   return `./${relativePath}`;
@@ -28167,7 +28168,11 @@ function normalizeErrors(filePath, errors) {
     rest = __objRest(_a, ['runtime']);
   if (runtime.length) {
     for (const error of runtime) {
-      annotations.push({ filePath: relativeFilePath, errors: error.errors.map((err) => [error.id, err]) });
+      const issues = error.errors.filter((err) => !IGNORE_LIST.includes(err));
+      if (!issues.length) {
+        continue;
+      }
+      annotations.push({ filePath: relativeFilePath, errors: issues.map((err) => [error.id, err]) });
     }
   }
   for (const command in rest) {


### PR DESCRIPTION
The majority of options are easy to run without a cloud context. But some parameters need more context.  This is the case of the  "Listen" parameter, which as you might suspect, it requires something to listen to. We will ignore annotating this type of option due to the lack of context in the cloud setup. 
